### PR TITLE
Adjustments to `starting_items` in schema

### DIFF
--- a/src/open_prime_hunters_rando/arm9.py
+++ b/src/open_prime_hunters_rando/arm9.py
@@ -8,14 +8,14 @@ def patch_arm9(rom: NintendoDSRom, starting_items: dict) -> None:
     # Validate starting_items string
     _validate_starting_items(starting_items)
 
-    starting_energy = starting_items["starting_ammo"]["energy"].to_bytes(4, "little")
-    starting_ammo = str(hex(starting_items["starting_ammo"]["ammo"] * 10))[2:-1]
-    starting_missiles = starting_items["starting_ammo"]["missiles"].to_bytes()
+    starting_energy = starting_items["energy"].to_bytes(4, "little")
+    starting_ammo = str(hex(starting_items["ammo"] * 10))[2:-1]
+    starting_missiles = starting_items["missiles"].to_bytes()
 
     ARM9_PATCHES = {
         init["starting_ammo"]: bytes.fromhex(starting_ammo),  # Starting UA Ammo
         init["starting_energy"]: bytes.fromhex("00F020E3"),  # NOP (Normally loads value of etank (100))
-        init["starting_weapons"]: int(starting_items["weapons_string"], 2).to_bytes(),  # Starting weapons
+        init["starting_weapons"]: int(starting_items["weapons"], 2).to_bytes(),  # Starting weapons
         init["starting_missiles"]: starting_missiles,  # Starting Missile ammo
         init["unlock_planets"]: bytes.fromhex("FF"),  # Unlock all planets from the start (excluding Oubliette)
         init["starting_energy_ptr"]: starting_energy,  # Starting energy - 1
@@ -40,13 +40,13 @@ def patch_arm9(rom: NintendoDSRom, starting_items: dict) -> None:
 
 def _validate_starting_items(starting_items: dict) -> None:
     # Validate weapons string
-    if len(starting_items["weapons_string"]) != 8:
+    if len(starting_items["weapons"]) != 8:
         raise ValueError(f"Invalid starting items string. Must contain 8 numbers, got {len(starting_items)}!")
 
-    for bit_flag in starting_items["weapons_string"]:
+    for bit_flag in starting_items["weapons"]:
         if bit_flag not in ["0", "1"]:
             raise ValueError(f"Invalid starting items string. String must only contain 0 or 1, got {bit_flag}!")
 
     # Validate starting ammo
-    if starting_items["starting_ammo"]["ammo"] > 400:
+    if starting_items["ammo"] > 400:
         raise ValueError(f"Starting ammo must be 400 or less! Got {starting_items['starting_ammo']['ammo']}")

--- a/src/open_prime_hunters_rando/arm9.py
+++ b/src/open_prime_hunters_rando/arm9.py
@@ -49,4 +49,4 @@ def _validate_starting_items(starting_items: dict) -> None:
 
     # Validate starting ammo
     if starting_items["ammo"] > 400:
-        raise ValueError(f"Starting ammo must be 400 or less! Got {starting_items['starting_ammo']['ammo']}")
+        raise ValueError(f"Starting ammo must be 400 or less! Got {starting_items['ammo']}")

--- a/src/open_prime_hunters_rando/files/schema.json
+++ b/src/open_prime_hunters_rando/files/schema.json
@@ -5,33 +5,30 @@
         "starting_items": {
             "type": "object",
             "properties": {
-                "weapons_string": {
+                "weapons": {
                     "type": "string",
                     "default": "00000101",
                     "description": "String of bits that determines what weapons to start with.\nLeft to Right: Shock Coil, Magmaul, Judicator, Imperialist, Battlehammer, Missile, Volt Driver, Power Beam"
                 },
-                "starting_ammo": {
-                    "type": "object",
-                    "propertyNames": {
-                        "type": "string",
-                        "enum": [
-                            "missiles",
-                            "energy",
-                            "ammo"
-                        ]
-                    },
-                    "default": {
-                        "missiles": 5,
-                        "energy": 100,
-                        "ammo": 40
-                    },
-                    "required": [
-                        "missiles"
-                    ]
+                "missiles": {
+                    "type": "integer",
+                    "default": 5,
+                    "description": "The number of missiles to start with."
+                },
+                "ammo": {
+                    "type": "integer",
+                    "default": 40,
+                    "description": "The amount of UA to start with."
+                },
+                "energy": {
+                    "type": "integer",
+                    "default": 100,
+                    "description": "The amount of energy to start with. In game, starting energy is this value minus 1."
                 }
             },
             "required": [
-                "weapons_string"
+                "weapons",
+                "missiles"
             ]
         },
         "areas": {

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../../src/open_prime_hunters_rando/files/schema.json",
     "starting_items": {
-        "weapons": "00100111",
+        "weapons": "00000101",
         "missiles": 0
     },
     "areas": {

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -1,7 +1,8 @@
 {
     "$schema": "../../src/open_prime_hunters_rando/files/schema.json",
     "starting_items": {
-        "weapons_string": "00000101"
+        "weapons": "00100111",
+        "missiles": 0
     },
     "areas": {
         "Celestial Archives": {


### PR DESCRIPTION
Removed the unnecessary dictionary of ammo in `starting_items`. Each field is now just listed individually.