### PR TITLE
Add option for modifying Hunters spawns

### DIFF
--- a/src/open_prime_hunters_rando/files/schema.json
+++ b/src/open_prime_hunters_rando/files/schema.json
@@ -2,6 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+        "configuration_id": {
+            "type": "string",
+            "description": "Identifier of the seed. Used for calculating RNG."
+        },
         "starting_items": {
             "type": "object",
             "properties": {
@@ -57,9 +61,26 @@
             },
             "default": {},
             "additionalProperties": false
+        },
+        "game_patches": {
+            "type": "object",
+            "properties": {
+                "shuffle_hunter_colors": {
+                    "type": "boolean",
+                    "description": "Changes the colors of the hunters.",
+                    "default": false
+                },
+                "shuffle_hunter_ids": {
+                    "type": "boolean",
+                    "description": "Changes the hunter spawns to be a different hunter.",
+                    "default": false
+                }
+            },
+            "default": {}
         }
     },
     "required": [
+        "configuration_id",
         "starting_items",
         "areas"
     ],

--- a/src/open_prime_hunters_rando/hunter_spawn_patches.py
+++ b/src/open_prime_hunters_rando/hunter_spawn_patches.py
@@ -1,0 +1,95 @@
+import random
+
+from construct import Container
+
+from open_prime_hunters_rando.entities.entity_type import EnemyType, EntityFile, EntityType, Hunter
+from open_prime_hunters_rando.file_manager import FileManager
+
+_ROOMS_WITH_HUNTERS = {
+    "Alinos": {
+        "Alinos Perch": {},
+        "Combat Hall": {},
+        "Council Chamber": {},
+        "Echo Hall": {},
+        "Elder Passage": {},
+        "High Ground": {21: 4},
+        "Processor Core": {},
+    },
+    "Celestial Archives": {
+        "Data Shrine 01": {},
+        "Data Shrine 02": {},
+        "Data Shrine 03": {3: 0},
+        "Docking Bay": {},
+        "Helm Room": {},
+        "Incubation Vault 01": {},
+        "Incubation Vault 02": {},
+        "Incubation Vault 03": {},
+        "Transfer Lock": {},
+    },
+    "Vesper Defense Outpost": {
+        "Compression Chamber": {},
+        "Stasis Bunker": {},
+        "Weapons Complex": {},
+    },
+    "Arcterra": {
+        "Arcterra Gateway": {},
+        "Fault Line": {},
+        "Sanctorus": {},
+        "Sic Transit": {},
+        "Subterranean": {},
+    },
+}
+
+
+def patch_hunters(file_manager: FileManager, configuration: dict) -> None:
+    shuffle_hunter_colors = configuration["game_patches"]["shuffle_hunter_colors"]
+    shuffle_hunter_ids = configuration["game_patches"]["shuffle_hunter_ids"]
+
+    if not shuffle_hunter_colors and not shuffle_hunter_ids:
+        return
+
+    random.seed(configuration["configuration_id"])
+
+    for area_name, room_names in _ROOMS_WITH_HUNTERS.items():
+        for room_name, encounter_type_entities in room_names.items():
+            entity_file = file_manager.get_entity_file(area_name, room_name)
+            for entity in entity_file.entities:
+                if entity.entity_type != EntityType.ENEMY_SPAWN:
+                    continue
+                if entity.data.enemy_type != EnemyType.HUNTER:
+                    continue
+
+                if shuffle_hunter_colors:
+                    # If enabled, change the hunter spawns to use a random color (0-6)
+                    entity.data.fields.hunter_color = random.choice(list(range(6)))
+
+                if shuffle_hunter_ids:
+                    # If enabled, generate a new hunter id (0-8) and modify the entity
+                    new_hunter_id = Hunter(random.choice(list(range(8))))
+                    hunter_data = entity.data.fields
+                    # Only modify the hunter fields if the hunter id is different
+                    if hunter_data.hunter_id != new_hunter_id:
+                        _patch_hunter_ids(hunter_data, new_hunter_id)
+                        _patch_encounter_types(entity_file, encounter_type_entities)
+
+
+def _patch_hunter_ids(hunter_data: Container, new_hunter_id: Hunter) -> None:
+    # Set the new hunter id
+    hunter_data.hunter_id = new_hunter_id
+    if new_hunter_id != Hunter.SPIRE:
+        if new_hunter_id == Hunter.GUARDIAN:
+            # Guardians can use weapon except Omega Cannon
+            hunter_data.hunter_weapon = random.choice(list(range(8)))
+        else:
+            # Hunters by default use a weapon value of 255
+            hunter_data.hunter_weapon = 255
+    else:
+        # Spire is the only non-Guardian hunter that has the weapon preset (might not be important)
+        hunter_data.hunter_weapon = 6
+
+
+def _patch_encounter_types(entity_file: EntityFile, encounter_type_entities: dict[int, int]) -> None:
+    # Handle certain hunter spawns not functioning properly
+    for entity_id, encounter_type in encounter_type_entities.items():
+        entity = entity_file.get_entity(entity_id)
+        entity.data.fields.encounter_type = encounter_type

--- a/src/open_prime_hunters_rando/hunter_spawn_patches.py
+++ b/src/open_prime_hunters_rando/hunter_spawn_patches.py
@@ -50,6 +50,20 @@ def patch_hunters(file_manager: FileManager, configuration: dict) -> None:
 
     random.seed(configuration["configuration_id"])
 
+    if shuffle_hunter_colors:
+        hunter_colors = list(range(6))
+        _HUNTERS_TO_COLOR = {
+            Hunter.SAMUS: random.choice(hunter_colors),
+            Hunter.KANDEN: random.choice(hunter_colors),
+            Hunter.TRACE: random.choice(hunter_colors),
+            Hunter.SYLUX: random.choice(hunter_colors),
+            Hunter.NOXUS: random.choice(hunter_colors),
+            Hunter.SPIRE: random.choice(hunter_colors),
+            Hunter.WEAVEL: random.choice(hunter_colors),
+            Hunter.GUARDIAN: random.choice(hunter_colors),
+            Hunter.RANDOM: random.choice(hunter_colors),
+        }
+
     for area_name, room_names in _ROOMS_WITH_HUNTERS.items():
         for room_name, encounter_type_entities in room_names.items():
             entity_file = file_manager.get_entity_file(area_name, room_name)
@@ -59,33 +73,48 @@ def patch_hunters(file_manager: FileManager, configuration: dict) -> None:
                 if entity.data.enemy_type != EnemyType.HUNTER:
                     continue
 
-                if shuffle_hunter_colors:
-                    # If enabled, change the hunter spawns to use a random color (0-6)
-                    entity.data.fields.hunter_color = random.choice(list(range(6)))
-
                 if shuffle_hunter_ids:
-                    # If enabled, generate a new hunter id (0-8) and modify the entity
-                    new_hunter_id = Hunter(random.choice(list(range(8))))
+                    # Have "Spire" spawns in High Ground and Elder Passage match
+                    if room_name == "High Ground" and entity.entity_id in [21, 60]:
+                        elder_passage = file_manager.get_entity_file("Alinos", "Elder Passage")
+                        spire_data = elder_passage.get_entity(9).data.fields
+                        new_hunter_id = spire_data.hunter_id
+                    # Spawning a Guardian causes a crash in Data Shrine 03 "Kanden" spawn
+                    elif room_name == "Data Shrine 02" and entity.entity_id == 12:
+                        new_hunter_id = Hunter(random.choice(list(range(1, 7))))
+                    # Have "Kanden" spawns in Data Shrine 02 and Data Shrine 03 match
+                    elif room_name == "Data Shrine 03" and entity.entity_id == 3:
+                        data_shrine_02 = file_manager.get_entity_file("Celestial Archives", "Data Shrine 02")
+                        kanden_data = data_shrine_02.get_entity(12).data.fields
+                        new_hunter_id = kanden_data.hunter_id
+                    # TODO: Figure out why Weapons Complex crashes when shuffling the hunters
+                    elif room_name == "Weapons Complex":
+                        continue
+                    else:
+                        # If enabled, generate a new hunter id (1-7) and modify the entity
+                        new_hunter_id = Hunter(random.choice(list(range(1, 8))))
+
                     hunter_data = entity.data.fields
                     # Only modify the hunter fields if the hunter id is different
                     if hunter_data.hunter_id != new_hunter_id:
                         _patch_hunter_ids(hunter_data, new_hunter_id)
                         _patch_encounter_types(entity_file, encounter_type_entities)
 
+                if shuffle_hunter_colors:
+                    # If enabled, change the hunter spawns to use a random color by hunter type (0-5)
+                    fields = entity.data.fields
+                    fields.hunter_color = _HUNTERS_TO_COLOR.get(fields.hunter_id, 0)
+
 
 def _patch_hunter_ids(hunter_data: Container, new_hunter_id: Hunter) -> None:
     # Set the new hunter id
     hunter_data.hunter_id = new_hunter_id
-    if new_hunter_id != Hunter.SPIRE:
-        if new_hunter_id == Hunter.GUARDIAN:
-            # Guardians can use weapon except Omega Cannon
-            hunter_data.hunter_weapon = random.choice(list(range(8)))
-        else:
-            # Hunters by default use a weapon value of 255
-            hunter_data.hunter_weapon = 255
+    if new_hunter_id == Hunter.GUARDIAN:
+        # Guardians can use weapon except Omega Cannon
+        hunter_data.hunter_weapon = random.choice(list(range(8)))
     else:
-        # Spire is the only non-Guardian hunter that has the weapon preset (might not be important)
-        hunter_data.hunter_weapon = 6
+        # Hunters by default use a weapon value of 255
+        hunter_data.hunter_weapon = 255
 
 
 def _patch_encounter_types(entity_file: EntityFile, encounter_type_entities: dict[int, int]) -> None:

--- a/src/open_prime_hunters_rando/prime_hunters_patcher.py
+++ b/src/open_prime_hunters_rando/prime_hunters_patcher.py
@@ -10,6 +10,7 @@ from open_prime_hunters_rando.arm9 import patch_arm9
 from open_prime_hunters_rando.entities.entity_patching import patch_entities
 from open_prime_hunters_rando.escape_sequence_patches import patch_escape_sequences
 from open_prime_hunters_rando.file_manager import FileManager
+from open_prime_hunters_rando.hunter_spawn_patches import patch_hunters
 from open_prime_hunters_rando.static_patches import static_patches
 from open_prime_hunters_rando.validator_with_default import DefaultValidatingDraft7Validator
 

--- a/src/open_prime_hunters_rando/prime_hunters_patcher.py
+++ b/src/open_prime_hunters_rando/prime_hunters_patcher.py
@@ -59,6 +59,9 @@ def patch_rom(input_path: Path, output_path: Path, configuration: dict) -> None:
     # Add new entities
     add_new_entities(file_manager)
 
+    # Patch Hunter Spawns
+    patch_hunters(file_manager, configuration)
+
     # Save all changes to a new rom
     file_manager.save_to_rom(output_path)
 

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../src/open_prime_hunters_rando/files/schema.json",
+    "configuration_id": "OPHRTEST",
     "starting_items": {
         "weapons": "00000101",
         "missiles": 0


### PR DESCRIPTION
(Relies on #55 to be merged first)

Adds two options:
- Option to randomize the color of the hunters

![image](https://github.com/user-attachments/assets/1f0874f6-370c-4448-96c8-d152d9fb887b)

- Option to randomize what hunter is spawned for each encounter

![image](https://github.com/user-attachments/assets/a0ca65ef-d525-4ba7-93d2-8fde0235a4fa)


Fixes #50 