### PR TITLE
Add option to configure which planets are open from the start

### DIFF
--- a/src/open_prime_hunters_rando/files/schema.json
+++ b/src/open_prime_hunters_rando/files/schema.json
@@ -74,6 +74,26 @@
                     "type": "boolean",
                     "description": "Changes the hunter spawns to be a different hunter.",
                     "default": false
+                },
+                "unlock_planets": {
+                    "type": "object",
+                    "description": "Choose which planets are unlocked from the start.",
+                    "properties": {
+                        "Alinos": {
+                            "type": "boolean"
+                        },
+                        "Arcterra": {
+                            "type": "boolean"
+                        },
+                        "Vesper Defense Outpost": {
+                            "type": "boolean"
+                        }
+                    },
+                    "default": {
+                        "Alinos": true,
+                        "Arcterra": true,
+                        "Vesper Defense Outpost": true
+                    }
                 }
             },
             "default": {}

--- a/src/open_prime_hunters_rando/prime_hunters_patcher.py
+++ b/src/open_prime_hunters_rando/prime_hunters_patcher.py
@@ -45,7 +45,7 @@ def patch_rom(input_path: Path, output_path: Path, configuration: dict) -> None:
     file_manager = FileManager(rom)
 
     # Modify main code file arm9.bin
-    patch_arm9(rom, configuration["starting_items"])
+    patch_arm9(rom, configuration)
 
     # Static patches to rooms
     static_patches(file_manager)


### PR DESCRIPTION
Planets get unlocked by defeating bosses. ASM work would be necessary to have these unlocks be items.