### PR TITLE
Fix portal spawn in Incubation Vault 03 from Docking Bay

### DIFF
--- a/src/open_prime_hunters_rando/static_patches.py
+++ b/src/open_prime_hunters_rando/static_patches.py
@@ -11,6 +11,7 @@ def static_patches(file_manager: FileManager) -> None:
     _disable_fault_line_imperialist_cutscene(file_manager)
     _patch_sic_transit_inner_door(file_manager)
     _lock_fault_line_magmaul_door(file_manager)
+    _fix_incubation_vault_03_portal_spawn(file_manager)
 
 
 def _disable_boss_force_fields(file_manager: FileManager) -> None:
@@ -97,3 +98,10 @@ def _lock_fault_line_magmaul_door(file_manager: FileManager) -> None:
     entity_file = file_manager.get_entity_file("Arcterra", "Fault Line")
     door = entity_file.get_entity(31)
     door.data.locked = True
+
+
+def _fix_incubation_vault_03_portal_spawn(file_manager: FileManager) -> None:
+    # The portal from Docking Bay to Incubation Vault 03 spawned Samus at the room spawn and not at the portal
+    entity_file = file_manager.get_entity_file("Celestial Archives", "Docking Bay")
+    portal = entity_file.get_entity(7)
+    portal.data.target_index = 27


### PR DESCRIPTION
Fixes a bug (I assume) from the vanilla game, where Samus will spawn at the room spawn point instead of at the portal. The `target_index` of the portal in Docking Bay is mismatched with the portal in Incubation Vault 03. No other room with portals has this issue.