### PR TITLE
Fix starting missiles not providing expected amount in game

### DIFF
--- a/src/open_prime_hunters_rando/arm9.py
+++ b/src/open_prime_hunters_rando/arm9.py
@@ -33,7 +33,7 @@ def patch_arm9(rom: NintendoDSRom, configuration: dict) -> None:
         init["weapon_slots"]: bytes.fromhex("00F020E3"),  # NOP to not delete the weapons when changing Octoliths
         init["starting_ammo"]: bytes.fromhex(starting_ammo),  # Starting UA
         init["starting_energy"]: bytes.fromhex("00F020E3"),  # NOP (Normally loads value of etank (100))
-        init["starting_missiles"]: starting_items["missiles"].to_bytes(),  # Starting Missiles
+        init["starting_missiles"]: (starting_items["missiles"] * 10).to_bytes(),  # Starting Missiles
         init["reordered_instructions"]: reordered_instructions,  # Changing R0 affects later instructions, so reorder
         init["unlock_planets"]: _unlock_planets(configuration["game_patches"]),  # Unlock planets from the start
         init["starting_energy_ptr"]: starting_energy,  # Starting energy - 1

--- a/src/open_prime_hunters_rando/files/schema.json
+++ b/src/open_prime_hunters_rando/files/schema.json
@@ -18,7 +18,8 @@
                 "missiles": {
                     "type": "integer",
                     "default": 5,
-                    "description": "The number of missiles to start with."
+                    "description": "The number of missiles to start with.",
+                    "maximum": 25
                 },
                 "ammo": {
                     "type": "integer",


### PR DESCRIPTION
Also sets a limit of 25 because the game takes the value * 10, so anything higher breaks.