### PR TITLE
Essential fixes

### DIFF
--- a/src/open_prime_hunters_rando/cli.py
+++ b/src/open_prime_hunters_rando/cli.py
@@ -20,7 +20,7 @@ def create_parser() -> argparse.ArgumentParser:
         "--input-json", type=Path, help="Path to the configuration json. If missing, it's read from standard input"
     )
     parser.add_argument(
-        "--export-parsed-files", type=bool, default=False, help="If true, exports the parsed entity files to a folder."
+        "--export-parsed-files", action="store_true", help="If included, exports the parsed entity files to a folder."
     )
     return parser
 

--- a/src/open_prime_hunters_rando/patching/asm/overlays.py
+++ b/src/open_prime_hunters_rando/patching/asm/overlays.py
@@ -6,12 +6,12 @@ OVERLAY_MODIFICATIONS: dict[int, list[dict[str, int]]] = {
     2: [
         {
             # Assign new Nothing scan entry to Nothing item (Cloak) in the item_scan_id table
-            "offset": 0x01E26A,
+            "offset": 0x01E20A,
             "value": 0x1DA,
         },
         {
             # Assign the Missile Launcher scan entry to Affinity Weapon in the item_scan_id table
-            "offset": 0x01E272,
+            "offset": 0x01E212,
             "value": 0x5,
         },
     ]

--- a/src/open_prime_hunters_rando/patching/version_checking.py
+++ b/src/open_prime_hunters_rando/patching/version_checking.py
@@ -38,7 +38,8 @@ def get_rom_save_data_addresses(rom: NintendoDSRom) -> SaveStoryAddresses:
             return SaveStoryAddresses(0x0)
         case Revision.AMHP.value:
             return SaveStoryAddresses(0x8C0)
-        case Revision.AMHJ.value:
-            return SaveStoryAddresses(0x1CF0)
+        # TODO: Support Japanese version
+        # case Revision.AMHJ.value:
+        # return SaveStoryAddresses(0x1CF0)
         case _:
             raise ValueError(f"Unsupported ROM detected. Detected {id_code!r}!")

--- a/src/open_prime_hunters_rando/patching/version_checking.py
+++ b/src/open_prime_hunters_rando/patching/version_checking.py
@@ -19,15 +19,15 @@ class SaveStoryAddresses:
         self.ammo_per_expansion = 0x0201A3AC
 
         # Addresses that are different across revisions (Using US as a base)
-        self.starting_octoliths = 0x0205C4E8 + revision_offset
-        self.starting_weapons = 0x0205C4F0 + revision_offset
-        self.weapon_slots = 0x0205C500 + revision_offset
-        self.starting_ammo = 0x0205C514 + revision_offset
-        self.starting_energy = 0x0205C518 + revision_offset
-        self.starting_missiles = 0x0205C530 + revision_offset
-        self.reordered_instructions = 0x0205C53C + revision_offset
-        self.unlock_planets = 0x0205C5DC + revision_offset
-        self.starting_energy_ptr = 0x0205C720 + revision_offset
+        self.starting_octoliths = 0x0205BCD4 + revision_offset
+        self.starting_weapons = 0x0205BCDC + revision_offset
+        self.weapon_slots = 0x0205BCEC + revision_offset
+        self.starting_ammo = 0x0205DB00 + revision_offset
+        self.starting_energy = 0x0205BD04 + revision_offset
+        self.starting_missiles = 0x0205BD1C + revision_offset
+        self.reordered_instructions = 0x0205BD28 + revision_offset
+        self.unlock_planets = 0x0205BDC8 + revision_offset
+        self.starting_energy_ptr = 0x0205BF0C + revision_offset
 
 
 def get_rom_save_data_addresses(rom: NintendoDSRom) -> SaveStoryAddresses:
@@ -37,8 +37,8 @@ def get_rom_save_data_addresses(rom: NintendoDSRom) -> SaveStoryAddresses:
         case Revision.AMHE.value:
             return SaveStoryAddresses(0x0)
         case Revision.AMHP.value:
-            return SaveStoryAddresses(0xAC)
+            return SaveStoryAddresses(0x8C0)
         case Revision.AMHJ.value:
-            return SaveStoryAddresses(0x14DC)
+            return SaveStoryAddresses(0x1CF0)
         case _:
             raise ValueError(f"Unsupported ROM detected. Detected {id_code!r}!")


### PR DESCRIPTION
- Fixes incorrect offsets used by SaveStoryAddresses and Overlays
- Fixes CLI to properly allow for choosing to export parsed files
- Prevents a JP rom from being used until proper support is added