### PR TITLE
Weird fix for Data Shrine 03

### DIFF
--- a/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
+++ b/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
@@ -165,6 +165,8 @@ def _patch_both_escape_layers(file_manager: FileManager) -> None:
                 if entity.entity_id in skipped_entities:
                     continue
                 # Ensure entities on layer 0 are loaded on layer 1 (during escape) and layer 2 (post escape)
-                elif entity.layer_state[0]:
+                if room_name in "Data Shrine 03":
+                    entity.layer_state[0] = True
+                if entity.layer_state[0]:
                     entity.layer_state[1] = True
                     entity.layer_state[2] = True

--- a/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
+++ b/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
@@ -164,9 +164,10 @@ def _patch_both_escape_layers(file_manager: FileManager) -> None:
                 # Skip modifying any entities in this list
                 if entity.entity_id in skipped_entities:
                     continue
-                # Ensure entities on layer 0 are loaded on layer 1 (during escape) and layer 2 (post escape)
+                # Workaraound for Data Shrine 03 to prevent softlocking
                 if room_name in "Data Shrine 03":
                     entity.layer_state[0] = True
+                # Ensure entities on layer 0 are loaded on layer 1 (during escape) and layer 2 (post escape)
                 if entity.layer_state[0]:
                     entity.layer_state[1] = True
                     entity.layer_state[2] = True

--- a/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
+++ b/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
@@ -165,7 +165,7 @@ def _patch_both_escape_layers(file_manager: FileManager) -> None:
                 if entity.entity_id in skipped_entities:
                     continue
                 # Workaraound for Data Shrine 03 to prevent softlocking
-                if room_name in "Data Shrine 03":
+                if room_name == "Data Shrine 03":
                     entity.layer_state[0] = True
                 # Ensure entities on layer 0 are loaded on layer 1 (during escape) and layer 2 (post escape)
                 if entity.layer_state[0]:


### PR DESCRIPTION
Seems like for this room if I just have all entities be on all three layers there is no potential softlock. The side effect is the Guardians spawn with Kanden so its a lot of fighting, but it's better than it not working at all.