### PR TITLE
Disable 2nd pass Voldrum and Psycho Bit Spawners

### DIFF
--- a/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
+++ b/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
@@ -133,7 +133,7 @@ def _patch_both_escape_layers(file_manager: FileManager) -> None:
             "Data Shrine 03": [],
             "Docking Bay": [],
             "Incubation Vault 01": [],
-            "Incubation Vault 02": [],
+            "Incubation Vault 02": [5, 11],  # 2nd pass Voldrum and Psycho Bit Spawners
             "New Arrival Registration": [],
             "Synergy Core": [],
             "Tetra Vista": [],
@@ -158,11 +158,11 @@ def _patch_both_escape_layers(file_manager: FileManager) -> None:
         },
     }
     for area_name, room_names in room_to_patch.items():
-        for room_name, skipped_entities in room_names.items():
+        for room_name, excluded_entities in room_names.items():
             entity_file = file_manager.get_entity_file(area_name, room_name)
             for entity in entity_file.entities:
                 # Skip modifying any entities in this list
-                if entity.entity_id in skipped_entities:
+                if entity.entity_id in excluded_entities:
                     continue
                 # Workaraound for Data Shrine 03 to prevent softlocking
                 if room_name == "Data Shrine 03":

--- a/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
+++ b/src/open_prime_hunters_rando/patching/escape_sequence_patches.py
@@ -161,9 +161,10 @@ def _patch_both_escape_layers(file_manager: FileManager) -> None:
         for room_name, excluded_entities in room_names.items():
             entity_file = file_manager.get_entity_file(area_name, room_name)
             for entity in entity_file.entities:
-                # Skip modifying any entities in this list
+                # Disable entities in this list
                 if entity.entity_id in excluded_entities:
-                    continue
+                    entity.layer_state[1] = False
+                    entity.layer_state[2] = False
                 # Workaraound for Data Shrine 03 to prevent softlocking
                 if room_name == "Data Shrine 03":
                     entity.layer_state[0] = True


### PR DESCRIPTION
Not to fix a softlock, but to fix a duplication error regarding unused spawners.