### PR TITLE
Move missile_launcher in weapons lower in default

### DIFF
--- a/src/open_prime_hunters_rando/files/schema.json
+++ b/src/open_prime_hunters_rando/files/schema.json
@@ -38,10 +38,10 @@
                     },
                     "default": {
                         "battlehammer": false,
-                        "missile_launcher": false,
                         "imperialist": false,
                         "judicator": false,
                         "magmaul": false,
+                        "missile_launcher": false,
                         "shock_coil": false,
                         "volt_driver": false
                     }


### PR DESCRIPTION
It doesn't change functionality but defaults are alphabetized otherwise