### PR TITLE
Force `has_base` to be false for Octoliths

### DIFF
--- a/src/open_prime_hunters_rando/parsing/formats/entities/entity_types/artifact.py
+++ b/src/open_prime_hunters_rando/parsing/formats/entities/entity_types/artifact.py
@@ -1,15 +1,30 @@
+import enum
 import typing
 
 from construct import Byte, Construct, Flag, Int16sl, Padded, Struct
 
 from open_prime_hunters_rando.parsing.common_types import MessageConstruct
 from open_prime_hunters_rando.parsing.common_types.vectors import Vec3
+from open_prime_hunters_rando.parsing.construct_extensions import EnumAdapter
 from open_prime_hunters_rando.parsing.formats.entities.base_entity import Entity
 from open_prime_hunters_rando.parsing.formats.entities.entity_classes import field
 from open_prime_hunters_rando.parsing.formats.entities.enum import EntityType, Message
 
+
+class ModelId(enum.Enum):
+    ALINOS1 = 0
+    ALINOS2 = 1
+    CELESTIAL_ARCHIVES1 = 2
+    CELESTIAL_ARCHIVES2 = 3
+    VDO1 = 4
+    VDO2 = 5
+    ARCTERRA1 = 6
+    ARCTERRA2 = 7
+    OCTOLITH = 8
+
+
 ArtifactEntityData = Struct(
-    "model_id" / Byte,
+    "model_id" / EnumAdapter(ModelId, Byte),
     "artifact_id" / Byte,
     "active" / Flag,
     "has_base" / Flag,
@@ -28,7 +43,7 @@ class Artifact(Entity):
     def type_construct(cls) -> Construct:
         return ArtifactEntityData
 
-    model_id = field(int)
+    model_id = field(ModelId)
     artifact_id = field(int)
 
     active = field(bool)
@@ -58,7 +73,7 @@ class Artifact(Entity):
         position: Vec3 | tuple[float, float, float] = (0.0, 0.0, 0.0),
         up_vector: Vec3 | tuple[float, float, float] = (0.0, 0.0, 0.0),
         facing_vector: Vec3 | tuple[float, float, float] = (0.0, 0.0, 0.0),
-        model_id: int = 0,
+        model_id: ModelId = ModelId.ALINOS1,
         artifact_id: int = 0,
         active: bool = True,
         has_base: bool = False,

--- a/src/open_prime_hunters_rando/patching/entities/pickup.py
+++ b/src/open_prime_hunters_rando/patching/entities/pickup.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, TypedDict
 
 from open_prime_hunters_rando.parsing.formats.entities.entity_file import EntityFile
-from open_prime_hunters_rando.parsing.formats.entities.entity_types.artifact import Artifact
+from open_prime_hunters_rando.parsing.formats.entities.entity_types.artifact import Artifact, ModelId
 from open_prime_hunters_rando.parsing.formats.entities.entity_types.item_spawn import ItemSpawn
 from open_prime_hunters_rando.parsing.formats.entities.entity_types.trigger_volume import (
     TriggerVolume,
@@ -62,10 +62,11 @@ def _patch_pickup(entity_file: EntityFile, pickup: PickupProperties) -> None:
                 _remove_shield_key_messages(entity)
 
             new_entity = Artifact.create(
-                model_id=pickup["model_id"],
+                model_id=ModelId(pickup["model_id"]),
                 artifact_id=pickup["artifact_id"],
                 active=entity.enabled,
-                has_base=entity.has_base,
+                # Octoliths do no have a base and will crash if "has_base" is true
+                has_base=entity.has_base if pickup["model_id"] != ModelId.OCTOLITH else False,
                 message1_target=entity.notify_entity_id,
                 message1=entity.collected_message,
                 linked_entity_id=(-1 if entity.parent_id == 65535 else entity.parent_id),
@@ -80,8 +81,11 @@ def _patch_pickup(entity_file: EntityFile, pickup: PickupProperties) -> None:
 
         # Entity is still Artifact
         if new_entity_type == EntityType.ARTIFACT:
-            entity.model_id = pickup["model_id"]
+            entity.model_id = ModelId(pickup["model_id"])
             entity.artifact_id = pickup["artifact_id"]
+            # Octoliths do no have a base and will crash if "has_base" is true
+            if entity.model_id == ModelId.OCTOLITH:
+                entity.has_base = False
 
         # Entity is now ItemSpawn
         else:


### PR DESCRIPTION
Prevents a crash from happening if the entity it replaces has one, as Octoliths do no not have a base.

Part 1 of #27 