### PR TITLE
Disable random encounters in Weapons Complex

### DIFF
--- a/src/open_prime_hunters_rando/patching/entities/escape_sequence_patches.py
+++ b/src/open_prime_hunters_rando/patching/entities/escape_sequence_patches.py
@@ -108,6 +108,7 @@ def _patch_specific_layer_states(file_manager: FileManager) -> None:
             "Weapons Complex": [
                 ([5], [1], True),  # Sylux ship on escape layer
                 ([27, 33], [2, 3], False),  # FIXME: Sylux ship cannon and camera sequence on second pass to save memory
+                ([52, 91], [2], False),  # FIXME: Sylux is always loaded in memory which crashes with random encounters
             ]
         },
         "Arcterra": {


### PR DESCRIPTION
There's a memory issue in Weapons Complex which is related to how the escape sequence patches are handled. There's a lot going on in this room so it's already being pushed to the limit. In my testing, it looks like the main culprit for this issue is Sylux. Even if fought prior, Sylux's entities are still loaded into memory even though they aren't currently active. I did remove them to see if it would crash and it didn't.

In this PR I had to choose between not having Sylux exist on layer 2 and just have the item that drops always be there, or remove the random encounters for this room for now until a better solution is found. I felt it was better to keep Sylux but I could always revert this change in the future.